### PR TITLE
Fix currency not listed on gate io

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,6 +51,9 @@ def main():
     t = threading.Thread(target=search_and_update)
     t.start()
 
+    t2 = threading.Thread(target=get_all_currencies())
+    t2.start()
+
 
     while True:
         #try:
@@ -60,77 +63,81 @@ def main():
             if len(order) > 0:
 
                 for coin in list(order):
+                    f = open('currencies.json',)
+                    supported_currencies = json.load(f)
+                    print(supported_currencies)
+                    print("Coin is " + coin)
+                    if coin in supported_currencies:
+                        # store some necesarry trade info for a sell
+                        stored_price = float(order[coin]['price'])
+                        coin_tp = order[coin]['tp']
+                        coin_sl = order[coin]['sl']
+                        volume = order[coin]['volume']
+                        symbol = order[coin]['symbol']
 
-                    # store some necesarry trade info for a sell
-                    stored_price = float(order[coin]['price'])
-                    coin_tp = order[coin]['tp']
-                    coin_sl = order[coin]['sl']
-                    volume = order[coin]['volume']
-                    symbol = order[coin]['symbol']
+                        last_price = get_last_price(symbol, pairing)
+                        print(f'{last_price=}')
+                        print(f'{stored_price - (stored_price*sl /100)=}')
+                        # update stop loss and take profit values if threshold is reached
+                        if float(last_price) > stored_price + (stored_price*coin_tp /100) and enable_tsl:
+                            # increase as absolute value for TP
+                            new_tp = float(last_price) - (float(last_price)*ttp /100)
+                            # convert back into % difference from when the coin was bought
+                            new_tp = float( (new_tp - stored_price) / stored_price*100)
 
-                    last_price = get_last_price(symbol, pairing)
-                    print(f'{last_price=}')
-                    print(f'{stored_price - (stored_price*sl /100)=}')
-                    # update stop loss and take profit values if threshold is reached
-                    if float(last_price) > stored_price + (stored_price*coin_tp /100) and enable_tsl:
-                        # increase as absolute value for TP
-                        new_tp = float(last_price) - (float(last_price)*ttp /100)
-                        # convert back into % difference from when the coin was bought
-                        new_tp = float( (new_tp - stored_price) / stored_price*100)
+                            # same deal as above, only applied to trailing SL
+                            new_sl = float(last_price) + (float(last_price)*tsl /100)
+                            new_sl = float((new_sl - stored_price) / stored_price*100)
 
-                        # same deal as above, only applied to trailing SL
-                        new_sl = float(last_price) + (float(last_price)*tsl /100)
-                        new_sl = float((new_sl - stored_price) / stored_price*100)
-
-                        # new values to be added to the json file
-                        order[coin]['tp'] = new_tp
-                        order[coin]['sl'] = new_sl
-                        store_order('order.json', order)
-
-                        print(f'updated tp: {round(new_tp, 3)} and sl: {round(new_sl, 3)}')
-
-                    # close trade if tsl is reached or trail option is not enabled
-                    elif float(last_price) < stored_price - (stored_price*sl /100) or float(last_price) > stored_price + (stored_price*coin_tp /100) and not enable_tsl:
-                        try:
-                            # sell for real if test mode is set to false
-                            if not test_mode:
-                                sell = place_order(symbol, pairing, coin['volume']*99.5/100, 'sell', last_price)
-
-                            print(f"sold {coin} with {(float(last_price) - stored_price) / float(stored_price)*100}% PNL")
-
-                            # remove order from json file
-                            order.pop(coin)
+                            # new values to be added to the json file
+                            order[coin]['tp'] = new_tp
+                            order[coin]['sl'] = new_sl
                             store_order('order.json', order)
 
-                        except Exception as e:
-                            print(e)
+                            print(f'updated tp: {round(new_tp, 3)} and sl: {round(new_sl, 3)}')
 
-                        # store sold trades data
-                        else:
-                            if not test_mode:
-                                sold_coins[coin] = sell
-                                store_order('sold.json', sold_coins)
+                        # close trade if tsl is reached or trail option is not enabled
+                        elif float(last_price) < stored_price - (stored_price*sl /100) or float(last_price) > stored_price + (stored_price*coin_tp /100) and not enable_tsl:
+                            try:
+                                # sell for real if test mode is set to false
+                                if not test_mode:
+                                    sell = place_order(symbol, pairing, coin['volume']*99.5/100, 'sell', last_price)
+
+                                print(f"sold {coin} with {(float(last_price) - stored_price) / float(stored_price)*100}% PNL")
+
+                                # remove order from json file
+                                order.pop(coin)
+                                store_order('order.json', order)
+
+                            except Exception as e:
+                                print(e)
+
+                            # store sold trades data
                             else:
-                                sold_coins[coin] = {
-                                            'symbol':coin,
-                                            'price':last_price,
-                                            'volume':volume,
-                                            'time':datetime.timestamp(datetime.now()),
-                                            'profit': float(last_price) - stored_price,
-                                            'relative_profit_%': round((float(last_price) - stored_price) / stored_price*100, 3),
-                                            'id': 'test-order',
-                                            'text': 'test-order',
-                                            'create_time': datetime.timestamp(datetime.now()),
-                                            'update_time': datetime.timestamp(datetime.now()),
-                                            'currency_pair': f'{symbol}_{pairing}',
-                                            'status': 'closed',
-                                            'type': 'limit',
-                                            'account': 'spot',
-                                            'side': 'sell',
-                                            'iceberg': '0',
-                                            'price': last_price }
+                                if not test_mode:
+                                    sold_coins[coin] = sell
+                                    store_order('sold.json', sold_coins)
+                                else:
+                                    sold_coins[coin] = {
+                                                'symbol':coin,
+                                                'price':last_price,
+                                                'volume':volume,
+                                                'time':datetime.timestamp(datetime.now()),
+                                                'profit': float(last_price) - stored_price,
+                                                'relative_profit_%': round((float(last_price) - stored_price) / stored_price*100, 3),
+                                                'id': 'test-order',
+                                                'text': 'test-order',
+                                                'create_time': datetime.timestamp(datetime.now()),
+                                                'update_time': datetime.timestamp(datetime.now()),
+                                                'currency_pair': f'{symbol}_{pairing}',
+                                                'status': 'closed',
+                                                'type': 'limit',
+                                                'account': 'spot',
+                                                'side': 'sell',
+                                                'iceberg': '0',
+                                                'price': last_price }
 
-                                store_order('sold.json', sold_coins)
+                                    store_order('sold.json', sold_coins)
 
 
             # the buy block and logic pass
@@ -142,42 +149,50 @@ def main():
 
             if announcement_coin and announcement_coin not in order and announcement_coin not in sold_coins:
                 print(f'New annoucement detected: {announcement_coin}')
-                price = get_last_price(announcement_coin, pairing)
-                try:
-                    # Run a test trade if true
-                    if config['TRADE_OPTIONS']['TEST']:
-                        order[announcement_coin] = {
-                                    'symbol':announcement_coin,
-                                    'price':price,
-                                    'volume':qty,
-                                    'time':datetime.timestamp(datetime.now()),
-                                    'tp': tp,
-                                    'sl': sl,
-                                    'id': 'test-order',
-                                    'text': 'test-order',
-                                    'create_time': datetime.timestamp(datetime.now()),
-                                    'update_time': datetime.timestamp(datetime.now()),
-                                    'currency_pair': f'{announcement_coin}_{pairing}',
-                                    'status': 'filled',
-                                    'type': 'limit',
-                                    'account': 'spot',
-                                    'side': 'buy',
-                                    'iceberg': '0'
-                                    }
-                        print('PLACING TEST ORDER')
-                    # place a live order if False
+                if os.path.isfile('currencies.json'):
+                    supported_currencies = json.load(open('currencies.json',))
+                    print(supported_currencies)
+                    print("Coin is " + announcement_coin)
+                    if announcement_coin in supported_currencies:
+                        price = get_last_price(announcement_coin, pairing)
+                        try:
+                            # Run a test trade if true
+                            if config['TRADE_OPTIONS']['TEST']:
+                                order[announcement_coin] = {
+                                            'symbol':announcement_coin,
+                                            'price':price,
+                                            'volume':qty,
+                                            'time':datetime.timestamp(datetime.now()),
+                                            'tp': tp,
+                                            'sl': sl,
+                                            'id': 'test-order',
+                                            'text': 'test-order',
+                                            'create_time': datetime.timestamp(datetime.now()),
+                                            'update_time': datetime.timestamp(datetime.now()),
+                                            'currency_pair': f'{announcement_coin}_{pairing}',
+                                            'status': 'filled',
+                                            'type': 'limit',
+                                            'account': 'spot',
+                                            'side': 'buy',
+                                            'iceberg': '0'
+                                            }
+                                print('PLACING TEST ORDER')
+                            # place a live order if False
+                            else:
+                                order[announcement_coin] = place_order(announcement_coin, pairing, qty,'buy', price)
+                                order[announcement_coin]['tp'] = tp
+                                order[announcement_coin]['sl'] = sl
+
+                        except Exception as e:
+                            print(e)
+
+                        else:
+                            print(f"Order created with {qty} on {announcement_coin}")
+
+                            store_order('order.json', order)
                     else:
-                        order[announcement_coin] = place_order(announcement_coin, pairing, qty,'buy', price)
-                        order[announcement_coin]['tp'] = tp
-                        order[announcement_coin]['sl'] = sl
-
-                except Exception as e:
-                    print(e)
-
-                else:
-                    print(f"Order created with {qty} on {announcement_coin}")
-
-                    store_order('order.json', order)
+                        print(f"Coin " + announcement_coin + " is not supported on gate io")
+                        os.remove("new_listing.json")
             else:
                 print(f"No coins announced, or coin has already been bought/sold. Checking more frequently in case TP and SL need updating. You can comment me out, I live on line 176 in main.py")
 

--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -1,10 +1,16 @@
+import ast
+
 import requests
 import os.path, json
 import time
 
 from store_order import *
+from auth.gateio_auth import *
+from gate_api import ApiClient, Configuration, Order, SpotApi
 from load_config import *
 
+client = load_gateio_creds('auth/auth.yml')
+spot_api = SpotApi(ApiClient(client))
 
 def get_last_coin():
     """
@@ -58,3 +64,18 @@ def search_and_update():
         print("Checking for coin announcements every 1 minute (in a separate thread)")
 
         time.sleep(10)
+
+def get_all_currencies():
+    """
+    Get a list of all currencies supported on gate io
+    :return:
+    """
+    while True:
+        print("Getting the list of supported currencies from gate io")
+        all_currencies = ast.literal_eval(str(spot_api.list_currencies()))
+        currency_list = [currency['currency'] for currency in all_currencies]
+        with open('currencies.json', 'w') as f:
+            json.dump(currency_list, f, indent=4)
+            print("List of gate io currencies saved to currencies.json. Waiting 5 "
+                  "minutes before refreshing list...")
+        time.sleep(300)


### PR DESCRIPTION
Fix currency not listed on gate io by saving all supported currencies to a list and checking the announcement coin against the list.

Most changes in main.py start on line 152 and changes in new_listings_scraper.py start on line 68.