### PR TITLE
fix place_order()

### DIFF
--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -19,9 +19,10 @@ def get_last_coin():
     """
     Scrapes new listings page for and returns new Symbol when appropriate
     """
-    latest_announcement = requests.get(
-        "https://www.binance.com/bapi/composite/v1/public/cms/article/catalog/list/query?catalogId=48&pageNo=1&pageSize=15")
+    print("pulling announcement page")
+    latest_announcement = requests.get("https://www.binance.com/bapi/composite/v1/public/cms/article/catalog/list/query?catalogId=48&pageNo=1&pageSize=15")
     latest_announcement = latest_announcement.json()
+    print("finished pulling announcement page")
     latest_announcement = latest_announcement['data']['articles'][0]['title']
 
     found_coin = re.findall('\(([^)]+)', latest_announcement)


### PR DESCRIPTION
`coin['volume']` will throw a error `string indices must be integers` at the time of sale when `place_order` is being called.  

`coin['volume']` is not necessary here since we have already set this value to `volume` on line 72.