### PR TITLE
add cache buster

### DIFF
--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -21,7 +21,7 @@ def get_last_coin():
     Scrapes new listings page for and returns new Symbol when appropriate
     """
     logger.debug("Pulling announcement page")
-    latest_announcement = requests.get("https://www.binance.com/bapi/composite/v1/public/cms/article/catalog/list/query?catalogId=48&pageNo=1&pageSize=15")
+    latest_announcement = requests.get("https://www.binance.com/bapi/composite/v1/public/cms/article/catalog/list/query?catalogId=48&pageNo=1&pageSize=15&rnd=" + time.time())
     latest_announcement = latest_announcement.json()
     logger.debug("Finished pulling announcement page")
     latest_announcement = latest_announcement['data']['articles'][0]['title']


### PR DESCRIPTION
By adding a timestamp to the Binance Announcement API request we possibly can avoid any server-side caching.