### PR TITLE
feature/logging/display-fetch-message-once-a-minute

### DIFF
--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -71,12 +71,18 @@ def search_and_update():
     """
     Pretty much our main func
     """
+
+    count = 57
+
     while True:
         latest_coin = get_last_coin()
         if latest_coin:
             store_new_listing(latest_coin)
-        logger.info("Checking for coin announcements every 1 minute (in a separate "
-                   "thread)")
+
+        count = count + 3
+        if count % 60 == 0:
+            logger.info("One minute has passed.  Checking for coin announcements every 3 seconds (in a separate thread)")
+            count = 0
 
         time.sleep(3)
 


### PR DESCRIPTION
## feature/logging/display-fetch-message-once-a-minute

+ [x] Fetch every 3 seconds but log message only once a minute.

## Overview
The app fetches possible gate.io announcements every 3 seconds.  Don't log a message until one minute has passed.  This helps to not bloat the log file with too many of the same `Checking for coin announcements every 3 seconds (in a separate thread)` message.