### PR TITLE
move regular logging to debug

### DIFF
--- a/main.py
+++ b/main.py
@@ -224,7 +224,7 @@ def main():
                 get_all_currencies()
         else:
 
-            logger.info(
+            logger.debug(
                 "No coins announced, or coin has already been bought/sold. Checking more frequently in case TP and SL need updating")
 
         time.sleep(3)

--- a/new_listings_scraper.py
+++ b/new_listings_scraper.py
@@ -75,7 +75,7 @@ def search_and_update():
         latest_coin = get_last_coin()
         if latest_coin:
             store_new_listing(latest_coin)
-        logger.info("Checking for coin announcements every 1 minute (in a separate "
+        logger.debug("Checking for coin announcements every 1 minute (in a separate "
                    "thread)")
 
         time.sleep(3)


### PR DESCRIPTION
As the log is 'spammed' by two regular tasks, the log gets big pretty fast. Also, as an end user, I expect that the basic future works and not get logged in info but in debug.
This is a proposal as an alternative to the approach in #41.

Should we consider alternate the logging behavior on any other parts of the application?