### PR TITLE
Using 24h high to decide whether to buy in on a new announcement

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -9,6 +9,7 @@
     # In %
     SL: -3
     TP: 2
+    24H: 2
     ENABLE_TSL: True
     TSL: -4
     TTP: 2

--- a/trade_client.py
+++ b/trade_client.py
@@ -7,14 +7,13 @@ client = load_gateio_creds('auth/auth.yml')
 spot_api = SpotApi(ApiClient(client))
 
 
-def get_last_price(base,quote):
+def get_coin_info(base,quote):
     """
     Args:
     'DOT', 'USDT'
     """
     tickers = spot_api.list_tickers(currency_pair=f'{base}_{quote}')
-    assert len(tickers) == 1
-    return tickers[0].last
+    return tickers[0]
 
 
 def get_min_amount(base,quote):
@@ -36,8 +35,10 @@ def place_order(base,quote, amount, side, last_price):
     'DOT', 'USDT', 50, 'buy', 400
     """
     try:
-        order = Order(amount=str(float(amount)/float(last_price)), price=last_price, side=side, currency_pair=f'{base}_{quote}')
+        order = Order(amount=str(float(amount)/float(last_price)), price=last_price, side=side, currency_pair=f'{base}_{quote}', time_in_force='ioc')
         order = spot_api.create_order(order)
+        t = order
+        logger.info(f"PLACE ORDER: {t.side} | {t.id} | {t.account} | {t.type} | {t.currency_pair} | {t.status} | amount={t.amount} | price={t.price} | left={t.left} | filled_total={t.filled_total} | fill_price={t.fill_price}")
     except Exception as e:
         logger.error(e)
         raise


### PR DESCRIPTION
Pull the 24 high, then add a config option to choose how much higher the 24h high has to be above than the current price in % to not buy the coin.

i.e. you run the bot and it detects and announcement for xyz that has already "peaked", let's say at 100 and you have a 24h % set at 5% then if the current price of the coin is 95, the bot won't buy it.

Since this is a customizable number, you get to choose what you believe a big enough price difference is to skip buying. The 24h high pull runs before the current price pull so the price is less likely to be below the 24h price due to a delay in data pull.

I've added the changes and it appears to work. I tested it by adding a coin to new_listings.json to trick the bot into wanting to order it. Tested using RGT as an example, which has spiked already to 62.76 and landed on ~47 atm which is about a 35% difference. When the 24H setting in config was 30%, it did not buy the coin.also merged with Kekkokk's fork.

You can find Kekkokk's fork here: https://github.com/kekkokk/gateio-crypto-trading-bot-binance-announcements-new-coins/commit/62e9799fb6cee170dde4e825422614144b3c34e0