### PR TITLE
Reopen: logs are now placed in logging directory and split into daily files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ session.json
 
 # Ignore bot log
 bot.log
+/logs
 
 # Ignore currency list and old coins
 currencies.json

--- a/logger.py
+++ b/logger.py
@@ -1,5 +1,7 @@
+import os
 import logging
 from load_config import *
+from logging.handlers import TimedRotatingFileHandler
 
 
 # loads local configuration
@@ -9,13 +11,22 @@ log = logging
 
 # Set default log settings
 log_level = 'INFO'
+cwd = os.getcwd()
+log_dir = "logs"
 log_file = 'bot.log'
+log_path = os.path.join(cwd, log_dir, log_file)
+
+# create logging directory
+if not os.path.exists(log_dir):
+    os.mkdir(log_dir)
 
 # Get logging variables
 log_level = config['LOGGING']['LOG_LEVEL']
 log_file = config['LOGGING']['LOG_FILE']
+
+file_handler = TimedRotatingFileHandler(log_path, when="midnight")
 log.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
-                handlers=[logging.FileHandler(log_file), logging.StreamHandler()])
+                handlers=[file_handler, logging.StreamHandler()])
 logger = logging.getLogger(__name__)
 level = logging.getLevelName(log_level)
 logger.setLevel(level)


### PR DESCRIPTION
Reopen #71.

Since the size of the log file can be MASSIVE very quickly, it would be better to split them into several files and place them into a seperate folder.

With this change, log files are now split into daily files which means that there will be a log file for every day beginning on midnight. Also, the logs will now be placed into a seperate folder called "logs" with a date appendix.
