### PR TITLE
Gateio ticker cache fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ def main():
 
                     logger.info(f'get_last_price existing coin: {coin}')
                     obj = get_last_price(symbol, pairing, False)
-                    last_price = obj.last
+                    last_price = obj.price
                     logger.info("Finished get_last_price")
 
                     top_position_price = stored_price + (stored_price*coin_tp /100)
@@ -264,7 +264,7 @@ def main():
                         
                         # get latest price object
                         obj = get_last_price(announcement_coin, pairing, False)
-                        price = obj.last
+                        price = obj.price
 
                         if float(price) == 0:
                             continue # wait for positive price

--- a/trade_client.py
+++ b/trade_client.py
@@ -1,34 +1,43 @@
+from datetime import datetime
 from logger import logger
 
 from auth.gateio_auth import *
-from gate_api import ApiClient, Configuration, Order, SpotApi
-from gate_api.exceptions import ApiException, GateApiException
-
-from store_order import store_order
+from gate_api import ApiClient, Order, SpotApi
 
 client = load_gateio_creds('auth/auth.yml')
 spot_api = SpotApi(ApiClient(client))
-import json
+
+current_last_trade = None
 
 
-
-def get_last_price(base,quote, return_price_only):
+def get_last_price(base, quote, return_price_only):
     """
     Args:
     'DOT', 'USDT'
     """
-    tickers = spot_api.list_tickers(currency_pair=f'{base}_{quote}')
-    assert len(tickers) == 1
-    t = tickers[0]
+    global current_last_trade
+    trades = spot_api.list_trades(currency_pair=f'{base}_{quote}', limit=1)
+    assert len(trades) == 1
+    t = trades[0]
+
+    create_time_ms = datetime.utcfromtimestamp(int(t.create_time_ms.split('.')[0]) / 1000)
+    create_time_formatted = create_time_ms.strftime('%d-%m-%y %H:%M:%S.%f')
+
+    if current_last_trade and current_last_trade.id > t.id:
+        logger.debug(f"CACHED TRADEBOOK RESULT FOUND. RE-TRYING.")
+        return get_last_price(base=base, quote=quote, return_price_only=return_price_only)
+    else:
+        current_last_trade = t
+
     if return_price_only:
-        return t.last
-    
-    logger.info(f"GET PRICE: {t.currency_pair} | last={t.last} | change%={t.change_percentage} | lowest_ask={t.lowest_ask} | highest_bid={t.highest_bid} | base_volue={t.base_volume} | quote_volume={t.quote_volume}")
+        return t.price
+
+    logger.info(f"LATEST TRADE: {t.currency_pair} | id={t.id} | create_time%={create_time_formatted} | "
+                f"side={t.side} | amount={t.amount} | price={t.price}")
     return t
-    
 
 
-def get_min_amount(base,quote):
+def get_min_amount(base, quote):
     """
     Args:
     'DOT', 'USDT'
@@ -41,16 +50,20 @@ def get_min_amount(base,quote):
         return min_amount
 
 
-def place_order(base,quote, amount, side, last_price):
+def place_order(base, quote, amount, side, last_price):
     """
     Args:
     'DOT', 'USDT', 50, 'buy', 400
     """
     try:
-        order = Order(amount=str(float(amount)/float(last_price)), price=last_price, side=side, currency_pair=f'{base}_{quote}', time_in_force='ioc')
+        order = Order(amount=str(float(amount) / float(last_price)), price=last_price, side=side,
+                      currency_pair=f'{base}_{quote}', time_in_force='ioc')
         order = spot_api.create_order(order)
         t = order
-        logger.info(f"PLACE ORDER: {t.side} | {t.id} | {t.account} | {t.type} | {t.currency_pair} | {t.status} | amount={t.amount} | price={t.price} | left={t.left} | filled_total={t.filled_total} | fill_price={t.fill_price} | fee={t.fee} {t.fee_currency}")
+        logger.info(
+            f"PLACE ORDER: {t.side} | {t.id} | {t.account} | {t.type} | {t.currency_pair} | {t.status} | "
+            f"amount={t.amount} | price={t.price} | left={t.left} | filled_total={t.filled_total} | "
+            f"fill_price={t.fill_price} | fee={t.fee} {t.fee_currency}")
     except Exception as e:
         logger.error(e)
         raise

--- a/trade_client.py
+++ b/trade_client.py
@@ -24,7 +24,7 @@ def get_last_price(base, quote, return_price_only):
     create_time_formatted = create_time_ms.strftime('%d-%m-%y %H:%M:%S.%f')
 
     if current_last_trade and current_last_trade.id > t.id:
-        logger.debug(f"CACHED TRADEBOOK RESULT FOUND. RE-TRYING.")
+        logger.debug(f"STALE TRADEBOOK RESULT FOUND. RE-TRYING.")
         return get_last_price(base=base, quote=quote, return_price_only=return_price_only)
     else:
         current_last_trade = t
@@ -32,7 +32,7 @@ def get_last_price(base, quote, return_price_only):
     if return_price_only:
         return t.price
 
-    logger.info(f"LATEST TRADE: {t.currency_pair} | id={t.id} | create_time%={create_time_formatted} | "
+    logger.info(f"LATEST TRADE: {t.currency_pair} | id={t.id} | create_time={create_time_formatted} | "
                 f"side={t.side} | amount={t.amount} | price={t.price}")
     return t
 


### PR DESCRIPTION
Use trade book instead of ticker to get the last price. This allows us to use the ID to detect stale responses, and retry the request.