### PR TITLE
Fix issue where order can become invalid

### DIFF
--- a/main.py
+++ b/main.py
@@ -209,7 +209,7 @@ def buy():
                             
                             # order not filled, try again.
                             logger.info(f"Clearing order with a status of {order_status}.  Waiting for 'closed' status")
-                            order.clear()  # reset for next iteration
+                            order.pop(announcement_coin)  # reset for next iteration
                 else:
                     logger.warning(f'{announcement_coin=} is not supported on gate io')
                     logger.info(f"Adding {announcement_coin} to old_coins.json")


### PR DESCRIPTION
Issue #94 

+ Fix issue where order can become invalid
The order should not be cleared. This action wipes all known orders and stops the bot from handling multiple orders.  We should only be removing the coin's data from the order dictionary.

The issue is produced only when a buy order is returned as `cancelled`.  See image for log where this edge case occurred.


![image](https://user-images.githubusercontent.com/4298131/143291662-7e2a7e0e-514c-4bc0-869c-17003e6c6a7f.png)
