### PR TITLE
Validate API keys when starting bot in live mode

### DIFF
--- a/src/gateio_new_coins_announcements_bot/main.py
+++ b/src/gateio_new_coins_announcements_bot/main.py
@@ -15,6 +15,7 @@ from gateio_new_coins_announcements_bot.new_listings_scraper import store_old_co
 from gateio_new_coins_announcements_bot.store_order import load_order
 from gateio_new_coins_announcements_bot.store_order import store_order
 from gateio_new_coins_announcements_bot.trade_client import get_last_price
+from gateio_new_coins_announcements_bot.trade_client import is_api_key_valid
 from gateio_new_coins_announcements_bot.trade_client import place_order
 
 # To add a coin to ignore, add it to the json array in old_coins.json
@@ -459,6 +460,15 @@ def sell():
         time.sleep(3)
 
 
+def validate_gateio_api_key():
+    if is_api_key_valid():
+        logger.info("Gate.io api keys are valid!")
+    else:
+        raise Exception(
+            "Gate-io API keys are invalid. Please make sure you are using the correct v4 keys with read/write enabled."
+        )
+
+
 def main():
     """
     Sells, adjusts TP and SL according to trailing values
@@ -485,6 +495,7 @@ def main():
 
     if not globals.test_mode:
         logger.info("!!! LIVE MODE !!!")
+        validate_gateio_api_key()
 
     t_get_currencies_thread = threading.Thread(target=get_all_currencies)
     t_get_currencies_thread.start()

--- a/src/gateio_new_coins_announcements_bot/trade_client.py
+++ b/src/gateio_new_coins_announcements_bot/trade_client.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from gate_api import ApiClient
 from gate_api import Order
 from gate_api import SpotApi
+from gate_api.exceptions import GateApiException
 
 from gateio_new_coins_announcements_bot.auth.gateio_auth import load_gateio_creds
 from gateio_new_coins_announcements_bot.logger import logger
@@ -81,3 +82,12 @@ def place_order(base, quote, amount, side, last_price):
 
     else:
         return order
+
+
+def is_api_key_valid():
+    try:
+        # try to call a method that requires the api key
+        spot_api.list_all_open_orders()
+        return True
+    except GateApiException:
+        return False


### PR DESCRIPTION
+ test-calling list_all_open_orders()  to make sure
the api keys are valid
+ This does not validate if the keys are write-enabled