### PR TITLE
Changed domain binancezh.com to binance.com 

### DIFF
--- a/src/gateio_new_coins_announcements_bot/new_listings_scraper.py
+++ b/src/gateio_new_coins_announcements_bot/new_listings_scraper.py
@@ -47,7 +47,7 @@ def get_announcement():
     random.shuffle(queries)
     logger.debug(f"Queries: {queries}")
     request_url = (
-        f"https://www.binancezh.com/gateway-api/v1/public/cms/article/list/query"
+        f"https://www.binance.com/gateway-api/v1/public/cms/article/list/query"
         f"?{queries[0]}&{queries[1]}&{queries[2]}&{queries[3]}&{queries[4]}&{queries[5]}"
     )
     latest_announcement = requests.get(request_url)


### PR DESCRIPTION
binancezh.com is no longer a valid binance domain.
To temporarily fix the issue I changed it back to binance.com.
In the future we should implement some other solution to always access the fastest domain.