### PR TITLE
Update requirements + bump pytest-cov to 3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 # API Dockerfile
 FROM python:3.9-alpine
 
-# Copy requirements file and install them
+# Copy requirements file
 COPY requirements.txt .
-RUN pip3 install -r requirements.txt
 
 # Copy module files
 COPY src/gateio_new_coins_announcements_bot ./src/gateio_new_coins_announcements_bot
@@ -13,9 +12,6 @@ COPY setup.cfg .
 COPY setup.py .
 COPY main.py .
 
-# Install files in src/gateio_new_coins_announcements_bot as module
-RUN pip3 install -e .
-
 # Copy relevant files to run bot
 COPY config.yml .
 COPY old_coins.json .
@@ -23,5 +19,8 @@ COPY auth/auth.yml ./auth/
 
 #root directory contains main.py to start the bot as well as all config/auth.yml files
 WORKDIR .
+
+# install necessary requirements
+RUN pip3 install -r requirements.txt
 
 CMD [ "python", "main.py"]

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,7 @@
 flake8==3.9.2
 tox==3.24.3
 pytest==6.2.5
-pytest-cov==2.12.1
+pytest-cov==3.0.0
 mypy==0.910
 pre-commit==2.15.0
 black==21.12b0

--- a/development_setup.md
+++ b/development_setup.md
@@ -16,26 +16,19 @@
 
 This contains the requirements for the program itself.
 
-## 4. Install the source code as module
-
-    python -m pip install -e .
-
-This installs the source code as a module so dependencies can be referenced easier.
-If you just wanna test/use the bot, you can stop here.
-
-## 5. Install dev requirements
+## 4. Install dev requirements
 
     python -m pip install -r dev_requirements.txt
 
 This is necessary make verifying of the code easier and formats the code automatically to match the coding style.
 
-## 6. Install pre-commit hooks
+## 5. Install pre-commit hooks
 
     pre-commit install
 
 This installs the pre-commit git hooks for the project and makes it possible to run the pre-commit script automatically when committing.
 
-## 7. Run Tests and pre-commit scripts manually
+## 6. Run Tests and pre-commit scripts manually
 ### pre-commit checks
 To manually run the pre-commit script:
 
@@ -53,7 +46,7 @@ Make sure you enabled the virtual environment.
 PyTest runs the unit tests for the code.
 To run PyTest:
 
-        pytest
+        python -m pytest
 
 
 ### Flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
+-e .
 requests==2.25.1
 gate_api==4.22.2
 PyYAML==6.0
-pytest==6.2.5

--- a/requirements_additional_build_agent.txt
+++ b/requirements_additional_build_agent.txt
@@ -1,5 +1,5 @@
 flake8==3.9.2
 tox==3.24.3
 pytest==6.2.5
-pytest-cov==2.12.1
+pytest-cov==3.0.0
 mypy==0.910


### PR DESCRIPTION
Its no longer necessary to run `python -m pip install -e` since the local module is now part of the requirements.txt and will get installed with `python -m pip install -r requirements.txt`.
I therefore also fixed the Dockerfile to install the modules after everything has been copied over.

 development_setup.md was edited to reflect these changes as well.