### PR TITLE
Grab first valid coin from multicoin announcement

### DIFF
--- a/src/gateio_new_coins_announcements_bot/new_listings_scraper.py
+++ b/src/gateio_new_coins_announcements_bot/new_listings_scraper.py
@@ -107,55 +107,50 @@ def get_kucoin_announcement():
         logger.error(f"Error pulling kucoin announcement page: {latest_announcement.status_code}")
         return ""
 
+def _extract_coins_from_announcement(annoucement):
+    word_blacklist = [
+        "Innovation Zone",
+        "Binance Futures",
+        "Launchpool"
+    ]
+
+    for word in word_blacklist:
+        if word in annoucement:
+            logger.info(f"Latest announcement: {annoucement}")
+            logger.info(f"Blacklisted word: \"{word}\" found in announcement, skipping")
+            return None
+
+    return re.findall(r"\(([^)]+)\)", annoucement)
+
 
 def get_last_coin():
     """
     Returns new Symbol when appropriate
     """
     # scan Binance Announcement
+    logger.info("Scanning Binance Announcement page...")
     latest_announcement = get_announcement()
 
-    # enable Kucoin Announcements if True in config
+    coins = _extract_coins_from_announcement(latest_announcement)
+
+    # if Kucoin Announcements are enabled in config
     if config["TRADE_OPTIONS"]["KUCOIN_ANNOUNCEMENTS"]:
         logger.info("Kucoin announcements enabled, look for new Kucoin coins...")
         kucoin_announcement = get_kucoin_announcement()
-        kucoin_coin = re.findall(r"\(([^)]+)", kucoin_announcement)
+        kucoin_coin = _extract_coins_from_announcement(kucoin_announcement)
+        coins.extend(kucoin_coin)
 
-    found_coin = re.findall(r"\(([^)]+)", latest_announcement)
-    uppers = None
+    if len(coins) > 0:
+        logger.debug(f"Found {len(coins)} new coins: {coins}. Picking first new coin...")
+        for coin in coins:
+            # return coin first new coin
+            if coin != globals.latest_listing and coin not in previously_found_coins:
+                    previously_found_coins.add(coin)
+                    logger.info("New coin detected: " + coin)
+                    return coin
 
-    # returns nothing if it's an old coin or it's not an actual coin listing
-    if (
-        "Will List" not in latest_announcement
-        or found_coin[0] == globals.latest_listing
-        or found_coin[0] in previously_found_coins
-    ):
-
-        # if the latest Binance announcement is not a new coin listing,
-        # or the listing has already been returned, check kucoin
-        if (
-            config["TRADE_OPTIONS"]["KUCOIN_ANNOUNCEMENTS"]
-            and "Gets Listed" in kucoin_announcement
-            and kucoin_coin[0] != globals.latest_listing
-            and kucoin_coin[0] not in previously_found_coins
-        ):
-            if len(kucoin_coin) == 1:
-                uppers = kucoin_coin[0]
-                previously_found_coins.add(uppers)
-                logger.info("New Kucoin coin detected: " + uppers)
-            if len(kucoin_coin) != 1:
-                uppers = None
-
-    else:
-        if len(found_coin) == 1:
-            uppers = found_coin[0]
-            previously_found_coins.add(uppers)
-            logger.info("New coin detected: " + uppers)
-        if len(found_coin) != 1:
-            uppers = None
-
-    return uppers
-
+    logger.debug("No new coins found")
+    return None
 
 def store_new_listing(listing):
     """

--- a/src/gateio_new_coins_announcements_bot/new_listings_scraper.py
+++ b/src/gateio_new_coins_announcements_bot/new_listings_scraper.py
@@ -141,7 +141,7 @@ def get_last_coin():
         coins.extend(kucoin_coin)
 
     if len(coins) > 0:
-        logger.debug(f"Found {len(coins)} new coins: {coins}. Picking first new coin...")
+        logger.debug(f"Detected {len(coins)} coins from announcements: {coins}. Picking first new coin...")
         for coin in coins:
             # return coin first new coin
             if coin != globals.latest_listing and coin not in previously_found_coins:

--- a/tests/test_new_listings_scraper.py
+++ b/tests/test_new_listings_scraper.py
@@ -1,15 +1,92 @@
 import pytest
 
-# import os
-# import sys
-
-# currentdir = os.path.dirname(os.path.realpath(__file__))
-# parentdir = os.path.dirname(currentdir)
-# sys.path.append(parentdir)
-
-
 @pytest.mark.skip("Can only be executed locally at this moment")
 def test_latest_announcement():
     from gateio_new_coins_announcements_bot.new_listings_scraper import get_announcement
 
     assert get_announcement()
+
+@pytest.mark.skip("Still needs patching to work")
+def test_get_last_coin_binance_detects_first_coin_in_single_coin_announcement():
+    """
+    Makes sure that the coin listed in the announcement is 
+    """
+    from gateio_new_coins_announcements_bot.new_listings_scraper import get_last_coin
+
+    #TODO: patch get_announcement() to return fake coin announcement
+    latest_announcement = "Binance Will List JOE (JOE)"
+
+    assert get_last_coin() == "JOE"
+
+test_get_last_coin_binance_detects_first_coin_in_single_coin_announcement()
+
+@pytest.mark.skip("Still needs patching to work")
+def test_get_last_coin_binance_detects_first_coin_in_multi_coin_announcement():
+    """
+    Makes sure that the first coin in a multi coin announcement is the one that is returned if it's not already listed
+    """
+    from gateio_new_coins_announcements_bot.new_listings_scraper import get_last_coin
+
+    #TODO: patch get_announcement() to return fake coin announcement
+    latest_announcement= "Binance Will List Alchemy Pay (ACH) and Immutable X (IMX)"
+    assert get_last_coin() == "ACH"
+
+@pytest.mark.skip("Still needs patching to work")
+def test_get_last_coin_binance_detects_second_coin_in_multi_coin_announcement_first_invalid():
+    """
+    Makes sure that the first coin in the announcement is not returned if it is not available or already listed
+    """
+    from gateio_new_coins_announcements_bot.new_listings_scraper import get_last_coin
+
+    #TODO: patch get_announcement() to return fake coin announcement
+    latest_announcement= "Binance Will List Alchemy Pay (ACH) and Immutable X (IMX)"
+    assert get_last_coin() == "IMX"
+
+
+@pytest.mark.skip("Still needs patching to work")
+def test_get_last_coin_binance_detects_no_coin_in_non_listing_coin_announcement():
+    """
+    Makes sure that the coin is only returned if its an actual listing on Binance Spot
+    """
+    from gateio_new_coins_announcements_bot.new_listings_scraper import get_last_coin
+
+    #TODO: patch get_announcement() to return fake coin announcement
+    latest_announcement = "Introducing Highstreet (HIGH) on Binance Launchpool! Farm HIGH by Staking BNB and BUSD Tokens"
+    assert get_last_coin() == None
+
+@pytest.mark.skip("Still needs patching to work")
+def test_get_last_coin_binance_detects_no_coin_in_non_listing_coin_announcement():
+    """
+    Makes sure that the coin is only returned if its an actual listing on Binance Spot
+    """
+    from gateio_new_coins_announcements_bot.new_listings_scraper import get_last_coin
+
+    #TODO: patch get_announcement() to return fake coin announcement
+    latest_announcement = "Binance Will List Convex Finance (CVX) and ConstitutionDAO (PEOPLE) in the Innovation Zone"
+    assert get_last_coin() == None
+
+
+@pytest.mark.skip("Still needs patching to work")
+def test_get_last_coin_kucoin_detects_first_coin_in_single_coin_announcement_with_world_premiere_string():
+    """
+    Makes sure that kucoin announcements are detected correctly if annoucement contains "World Premiere" string
+    """
+    from gateio_new_coins_announcements_bot.new_listings_scraper import get_last_coin
+
+    #TODO: patch get_announcement() to return fake coin announcement
+    #TODO: patch to enable kucoin scraping
+    latest_announcement = "Pledge (PLGR) Gets Listed on KuCoin! World Premiere!"
+    assert get_last_coin() == "PLGR"
+
+
+@pytest.mark.skip("Still needs patching to work")
+def test_get_last_coin_kucoin_detects_first_coin_in_single_coin_announcement_without_world_premiere_string():
+    """
+    Makes sure that kucoin announcements are detected correctly if annoucement does not contain "World Premiere" string
+    """
+    from gateio_new_coins_announcements_bot.new_listings_scraper import get_last_coin
+
+    #TODO: patch get_announcement() to return fake coin announcement
+    #TODO: patch to enable kucoin scraping
+    latest_announcement = "QuickSwap (QUICK) Gets Listed on KuCoin!"
+    assert get_last_coin() == "QUICK"


### PR DESCRIPTION
The is the first step to fixing multicoin announcements.
The idea is to grab the first in a multi-coin announcement.

It also refactores some parts of the announcement detection to use a blacklist of words.
If the announcement includes one of those words it will get ignored.