### PR TITLE
Fixed telegram query url

### DIFF
--- a/src/gateio_new_coins_announcements_bot/send_telegram.py
+++ b/src/gateio_new_coins_announcements_bot/send_telegram.py
@@ -42,8 +42,8 @@ class TelegramHandler(logging.Handler):
             return
 
         requests.get(
-            f"""https://api.telegram.org/bot{bot_token}/sendMessage
-            ?chat_id={bot_chatID}
-            &parse_mode=Markdown
-            &text={record.message}"""
+            f"https://api.telegram.org/bot{bot_token}/sendMessage"
+            f"?chat_id={bot_chatID}"
+            "&parse_mode=Markdown"
+            f"&text={record.message}"
         )


### PR DESCRIPTION
+ replaced multi-line string with concatenated single-line strings

As noticed by @warren-ru here:
https://github.com/CyberPunkMetalHead/gateio-crypto-trading-bot-binance-announcements-new-coins/commit/9de541baab4cf5622201306954bc4d1dc2c02a5a#r65068689

The telegram query url was invalid.